### PR TITLE
simplify poly async/sync code paths that aren't needed. Clock is alwa…

### DIFF
--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -220,6 +220,7 @@ class BucketFactory(ABC):
 
     _leaker: Optional[Leaker] = None
     _leak_interval: int = 10_000
+    clock: AbstractClock
 
     @property
     def leak_interval(self) -> int:
@@ -235,19 +236,15 @@ class BucketFactory(ABC):
             self._leaker.leak_interval = value
         self._leak_interval = value
 
-    @abstractmethod
-    def wrap_item(
-        self,
-        name: str,
-        weight: int = 1,
-    ) -> Union[RateItem, Awaitable[RateItem]]:
+    def wrap_item(self, name: str, weight: int = 1):
         """Add the current timestamp to the receiving item using any clock backend
         - Turn it into a RateItem
         - Can return either a coroutine or a RateItem instance
         """
+        return RateItem(name=name, timestamp=self.clock.now(), weight=weight)
 
     @abstractmethod
-    def get(self, item: RateItem) -> Union[AbstractBucket, Awaitable[AbstractBucket]]:
+    def get(self, item: RateItem) -> Union[AbstractBucket]:
         """Get the corresponding bucket to this item"""
 
     def create(

--- a/pyrate_limiter/abstracts/clock.py
+++ b/pyrate_limiter/abstracts/clock.py
@@ -1,12 +1,10 @@
 from abc import ABC
 from abc import abstractmethod
-from typing import Awaitable
-from typing import Union
 
 
 class AbstractClock(ABC):
     """Clock that return timestamp for `now`"""
 
     @abstractmethod
-    def now(self) -> Union[int, Awaitable[int]]:
+    def now(self) -> int:
         """Get time as of now, in miliseconds"""

--- a/pyrate_limiter/clocks.py
+++ b/pyrate_limiter/clocks.py
@@ -31,13 +31,6 @@ class TimeClock(AbstractClock):
         return int(1000 * time())
 
 
-class TimeAsyncClock(AbstractClock):
-    """Time Async Clock, meant for testing only"""
-
-    async def now(self) -> int:
-        return int(1000 * time())
-
-
 class SQLiteClock(AbstractClock):
     """Get timestamp using SQLite as remote clock backend"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ from pyrate_limiter import MultiprocessBucket
 from pyrate_limiter import PostgresBucket
 from pyrate_limiter import Rate
 from pyrate_limiter import RedisBucket
-from pyrate_limiter import TimeAsyncClock
 from pyrate_limiter import TimeClock
 
 
@@ -33,13 +32,11 @@ DEFAULT_RATES = [Rate(3, 1000), Rate(4, 1500)]
 clocks = [
     MonotonicClock(),
     TimeClock(),
-    TimeAsyncClock(),
 ]
 
 ClockSet = Union[
     MonotonicClock,
     TimeClock,
-    TimeAsyncClock,
 ]
 
 

--- a/tests/test_bucket_factory.py
+++ b/tests/test_bucket_factory.py
@@ -11,7 +11,6 @@ from .conftest import logger
 from .demo_bucket_factory import DemoBucketFactory
 from .helpers import async_count
 from pyrate_limiter import AbstractBucket
-from pyrate_limiter import RateItem
 
 
 @pytest.mark.asyncio
@@ -23,10 +22,6 @@ async def test_factory_01(clock, create_bucket):
 
     item = factory.wrap_item("hello", 1)
 
-    if isawaitable(item):
-        item = await item
-
-    assert isinstance(item, RateItem)
     assert item.weight == 1
 
     bucket = factory.get(item)
@@ -48,10 +43,6 @@ async def test_factory_leak(clock, create_bucket):
         for _ in range(3):
             is_async = False
             item = factory.wrap_item(item_name)
-
-            if isawaitable(item):
-                is_async = True
-                item = await item
 
             bucket = factory.get(item)
             put_ok = bucket.put(item)


### PR DESCRIPTION
…ys synchronous, so wrap_item can be synchronous and return a RateItem. get() always returns a bucket. The only exceptions for both were testing code paths.